### PR TITLE
Restrict bcrypt version to <5

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi[all]
 httpx
 uvicorn[standard]
 passlib[bcrypt]
+bcrypt <5
 psutil
 python-jose[cryptography]
 python-socketio


### PR DESCRIPTION
Starting with version 5.0.0, bcrypt will throw a ValueError if the input is more than 72 bytes.
passlib's `hash` processes the input such that more than 72 bytes are passed to bcrypt, independently of the input length. As a result, the backend of firegex breaks when calculating the hash in `set_psw`.