### PR TITLE
Add Content-Type=text/plain for metrics endpoint

### DIFF
--- a/backend/routers/nfregex.py
+++ b/backend/routers/nfregex.py
@@ -1,7 +1,8 @@
 from base64 import b64decode
 import secrets
 import sqlite3
-from fastapi import APIRouter, Response, HTTPException
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 from modules.nfregex.nftables import FiregexTables
 from modules.nfregex.firewall import STATUS, FirewallManager
@@ -332,7 +333,7 @@ async def add_new_service(form: ServiceAddForm):
     await refresh_frontend()
     return {'status': 'ok', 'service_id': srv_id}
 
-@app.get('/metrics', response_class = Response)
+@app.get('/metrics', response_class = PlainTextResponse)
 async def metrics():
     """Aggregate metrics"""
     stats = db.query("""


### PR DESCRIPTION
Without the content type, prometheus will reject the metrics if no `fallback_scrape_protocol` is specified.

https://prometheus.io/docs/prometheus/3.0/migration/#scrape-protocols https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format