### PR TITLE
Reduce docker image size by 35%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN g++ binsrc/nfproxy.cpp -o cpproxy -std=c++23 -O3 -lnetfilter_queue -lpython3
 #Building main conteiner
 FROM --platform=$TARGETARCH base AS final
 
-ADD ./backend/requirements.txt /execute/requirements.txt
+COPY ./backend/requirements.txt /execute/requirements.txt
 COPY ./fgex-lib /execute/fgex-lib
 
 RUN dnf -y update && dnf install -y gcc-c++ python3.13-devel uv git &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN bun run build
 # Base fedora container
 FROM --platform=$TARGETARCH quay.io/fedora/fedora:42 AS base
 RUN dnf -y update && dnf install -y python3.13 libnetfilter_queue \
-    libnfnetlink libmnl libcap-ng-utils nftables git \
-    vectorscan libtins python3-nftables libpcap uv
+    libnfnetlink libmnl libcap-ng-utils nftables \
+    vectorscan libtins python3-nftables libpcap && dnf clean all
 
 RUN mkdir -p /execute/modules
 WORKDIR /execute
@@ -37,10 +37,10 @@ FROM --platform=$TARGETARCH base AS final
 ADD ./backend/requirements.txt /execute/requirements.txt
 COPY ./fgex-lib /execute/fgex-lib
 
-RUN dnf install -y gcc-c++ python3.13-devel uv git &&\
+RUN dnf -y update && dnf install -y gcc-c++ python3.13-devel uv git &&\
     uv pip install --no-cache --system ./fgex-lib &&\
     uv pip install --no-cache --system -r /execute/requirements.txt &&\
-    dnf remove -y gcc-c++ python3.13-devel uv git
+    uv cache clean && dnf remove -y gcc-c++ python3.13-devel uv git && dnf clean all
 
 COPY ./backend/ /execute/
 COPY --from=compiler /execute/cppregex /execute/cpproxy /execute/modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ WORKDIR /execute
 FROM --platform=$TARGETARCH base AS compiler
 
 RUN dnf -y update && dnf install -y python3.13-devel @development-tools gcc-c++ \
-    libnetfilter_queue-devel libnfnetlink-devel libmnl-devel libcap-ng-utils nftables \
-    vectorscan-devel libtins-devel python3-nftables libpcap-devel boost-devel
+    libnetfilter_queue-devel libnfnetlink-devel libmnl-devel \
+    vectorscan-devel libtins-devel libpcap-devel boost-devel
 
 COPY ./backend/binsrc /execute/binsrc
 RUN g++ binsrc/nfregex.cpp -o cppregex -std=c++23 -O3 -lnetfilter_queue -pthread -lnfnetlink $(pkg-config --cflags --libs libtins libhs libmnl)


### PR DESCRIPTION
Since docker caches each instruction as a layer, we have to clean cached packages at the end of each step for minimal image size. As a drawback, we now have to download the package index again for the compiler and final container.