### PR TITLE
Fix caching problems on fresh restart

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,6 +120,7 @@ function App() {
         setLoadingBtn(true)
         await login(values).then(res => {
           if(!res){
+            queryClient.invalidateQueries()
             setSystemStatus({...systemStatus, loggined:true})
           }else{
             setError("Login failed")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,7 @@ function App() {
         }
       }).catch( err => setError(err.toString()))
       setLoadingBtn(false)
+      form.reset()
     }
     
 
@@ -125,6 +126,7 @@ function App() {
           }
         }).catch( err => setError(err.toString()))
         setLoadingBtn(false)
+        form.reset()
       }
     
 


### PR DESCRIPTION
When firegex looses the database on restart (for example due to `stop --clear` & `start`), several things fail/get out of sync:
- the password is already inserted in the password field
- the old nfregexs, ... are shown